### PR TITLE
fix: SmartQSave command on new buffer changes

### DIFF
--- a/autoload/smartq.vim
+++ b/autoload/smartq.vim
@@ -303,9 +303,9 @@ endfunction
 
 function! s:save_buf(bang, bufName)
   try
-    exec 'w' . a:bang . ' ' . a:bufName
+    silent execute 'w' . a:bang . ' ' . a:bufName
   " No file name
-  catch E32
+  catch /E32:/
     let root = getcwd() . '/'
     let newfile = input('New filename: ' . root, '', 'file')
 
@@ -320,12 +320,10 @@ function! s:save_buf(bang, bufName)
     if !isdirectory(dir)
       call mkdir(dir, 'p')
     endif
-    exec 'w' . a:bang . ' ' . newfile
-    return 0
+    silent execute 'w' . a:bang . ' ' . newfile
   endtry
 
-  call s:echo_error('Error writting to buffer ' . a:bufName . ' aborted!', 1)
-  return 1
+  return 0
 endfunction
 
 
@@ -363,6 +361,7 @@ function! smartq#smartq(bang, buffer, save) abort
   if &modifiable && getbufvar(bufNr, '&modified') == 1
     if a:save ==# v:true
       let save = s:save_buf(a:bang, bufName)
+      let bufName = bufname(bufNr)
       if save ==# 1
         return
       elseif save ==# 2


### PR DESCRIPTION
Hi @marklcrns ,

 In this PR, I am trying to fix `SmartQSave` command on new buffer changes

* Fix Error:
```
Error detected while processing function smartq#smartq[18]..<SNR>291_save_buf[20]..function smartq#smartq[18]..<SNR>291_save_buf:
line    4:
E654: Missing delimiter after search pattern: 32
```

* Fix Error: `Exit prevented. Only one buffer left.` after saving to new buffer

I also made a changes to silent save buffer.

Please help to review and accept this PR if you find that it does make senses.

Thanks.